### PR TITLE
Localization: Update German translation

### DIFF
--- a/config/translations/lxqt-config-appswitcher_de.ts
+++ b/config/translations/lxqt-config-appswitcher_de.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../config.ui" line="14"/>
         <source>LXQt Application Switcher Configuration</source>
-        <translation>LXQt Application Switcher Konfiguration</translation>
+        <translation>Konfiguration LXQt Anwendungsumschalter</translation>
     </message>
     <message>
         <location filename="../config.ui" line="20"/>

--- a/resources/lxqt-appswitcher.desktop
+++ b/resources/lxqt-appswitcher.desktop
@@ -10,5 +10,8 @@ OnlyShowIn=LXQt;
 X-LXQt-Module=true
 Hidden=true
 
+Name[de]=Anwendungsumschalter
+GenericName[de]=Anwendungsumschalter
+Comment[de]=Per Tastatur eine Liste laufender Anwendungen anzeigen und zwischen diesen wechseln.
 Name[it]=Scambiafinestre
 Comment[it]=Elenca e scambia le finestre aperte

--- a/resources/lxqt-config-appswitcher.desktop
+++ b/resources/lxqt-config-appswitcher.desktop
@@ -7,6 +7,7 @@ Icon=input-keyboard
 Categories=Qt;Settings;HardwareSettings;DesktopSettings;LXQt;
 OnlyShowIn=LXQt;
 
+Name[de]=Anwendungsumschalter
+Comment[de]=Konfiguration des LXQt Anwendungsumschalters
 Name[it]=Scambiafinestre
 Comment[it]=Configura lo scambiafinestre
-


### PR DESCRIPTION
In lxqt-appswitcher.desktop I've scrubbed string "LXQt" from key `Name` as I think this is more reasonable. If I'm not mistaken the only location where this string appears is in the GUI of `lxqt-config-session`. But there it's summarized in a pane titled "*LXQt* Modules" so stating string "LXQt" another time doesn't really make sense.
![lxqt-appswitcher_desktop-entry-vs-lxqt-config-session](https://cloud.githubusercontent.com/assets/9860801/19627805/1c478b94-9950-11e6-8d81-bfd836426930.png)

Notes:
Translating the desktop entry files made me wonder whether key `GenericName` of lxqt-appswitcher.desktop is used at all somewhere.
In `lxqt-config-session` the toolboxes displayed upon hovering are displayed in English only right now, see lxde/lxqt#1184.