### PR TITLE
Ported to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
-cmake_minimum_required(VERSION 2.8.11)
-cmake_policy(VERSION 2.8)
+cmake_minimum_required(VERSION 3.8.0)
+cmake_policy(VERSION 3.8)
 
 project(lxqt-appswitcher)
 include(GNUInstallDirs)
 
-find_package(Qt5 COMPONENTS Core Widgets)
+find_package(Qt6 COMPONENTS Core Widgets)
 find_package(lxqt)
 find_package(lxqt-globalkeys REQUIRED)
-find_package(KF5WindowSystem)
+find_package(KF6WindowSystem)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -43,8 +43,8 @@ add_executable(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-    Qt5::Core
-    Qt5::Widgets
+    Qt6::Core
+    Qt6::Widgets
     lxqt
     lxqt-globalkeys
 )

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,4 +1,4 @@
-qt5_wrap_ui(uic
+qt6_wrap_ui(uic
     config.ui
 )
 
@@ -31,8 +31,8 @@ add_executable(lxqt-config-appswitcher
 )
 
 target_link_libraries(lxqt-config-appswitcher
-    Qt5::Core
-    Qt5::Widgets
+    Qt6::Core
+    Qt6::Widgets
     lxqt
 )
 

--- a/src/app-model.cpp
+++ b/src/app-model.cpp
@@ -28,7 +28,6 @@
 #include "settings.h"
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QScreen>
 #include <KX11Extras>
 #include <KWindowInfo>

--- a/src/app-switcher.cpp
+++ b/src/app-switcher.cpp
@@ -31,7 +31,7 @@
 #include <LXQtGlobalKeys/Client>
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QKeyEvent>
 #include <QScreen>
 #include <QTimer>


### PR DESCRIPTION
Still some warnings to fix though:
```
[ 85%] Building CXX object CMakeFiles/lxqt-appswitcher.dir/lxqt-appswitcher_autogen/mocs_compilation.cpp.o
/home/stef/git/stefonarch/lxqt-appswitcher/config/config.cpp: In constructor ‘Config::Config(QWidget*)’:
/home/stef/git/stefonarch/lxqt-appswitcher/config/config.cpp:61:45: warning: ‘void QCheckBox::stateChanged(int)’ is deprecated: Use checkStateChanged() instead [-Wdeprecated-declarations]
   61 |     connect(m_ui->filterDskChk, &QCheckBox::stateChanged, this, &Config::save);
      |              
      ```